### PR TITLE
Implement API based SNUH login

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,6 +53,9 @@ dependencies {
     // 3. Kotlin Coroutines: 비동기 처리를 위함
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3")
 
+    // Lifecycle scope 사용을 위해
+    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.8.6")
+
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.appcompat)
     implementation(libs.material)

--- a/app/src/main/java/com/example/hospitalnotifier/MainActivity.kt
+++ b/app/src/main/java/com/example/hospitalnotifier/MainActivity.kt
@@ -3,13 +3,16 @@ package com.example.hospitalnotifier
 import android.os.Bundle
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.lifecycleScope
 import androidx.work.Data
 import androidx.work.ExistingPeriodicWorkPolicy
 import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
 import com.example.hospitalnotifier.databinding.ActivityMainBinding
+import com.example.hospitalnotifier.network.AuthRepository
 import com.example.hospitalnotifier.worker.ReservationWorker
 import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.launch
 
 class MainActivity : AppCompatActivity() {
 
@@ -34,29 +37,40 @@ class MainActivity : AppCompatActivity() {
                 return@setOnClickListener
             }
 
-            // Worker에게 전달할 데이터 꾸러미 만들기
-            val inputData = Data.Builder()
-                .putString("USER_ID", userId)
-                .putString("USER_PW", userPw)
-                .putString("TELEGRAM_TOKEN", telegramToken)
-                .putString("TELEGRAM_CHAT_ID", telegramChatId)
-                .build()
+            lifecycleScope.launch {
+                val loginResult = AuthRepository.login(userId, userPw)
+                if (loginResult.isSuccess) {
+                    // Worker에게 전달할 데이터 꾸러미 만들기
+                    val inputData = Data.Builder()
+                        .putString("USER_ID", userId)
+                        .putString("USER_PW", userPw)
+                        .putString("TELEGRAM_TOKEN", telegramToken)
+                        .putString("TELEGRAM_CHAT_ID", telegramChatId)
+                        .build()
 
-            // 15분마다 반복되는 작업 요청 생성 (WorkManager의 최소 반복 간격은 15분)
-            val reservationWorkRequest =
-                PeriodicWorkRequestBuilder<ReservationWorker>(15, TimeUnit.MINUTES)
-                    .setInputData(inputData)
-                    .build()
+                    // 15분마다 반복되는 작업 요청 생성 (WorkManager의 최소 반복 간격은 15분)
+                    val reservationWorkRequest =
+                        PeriodicWorkRequestBuilder<ReservationWorker>(15, TimeUnit.MINUTES)
+                            .setInputData(inputData)
+                            .build()
 
-            // 중복 실행을 막기 위해 고유한 이름으로 작업을 큐에 추가
-            workManager.enqueueUniquePeriodicWork(
-                "HospitalReservationCheck",
-                ExistingPeriodicWorkPolicy.UPDATE, // 이미 작업이 있다면 새 것으로 교체
-                reservationWorkRequest
-            )
+                    // 중복 실행을 막기 위해 고유한 이름으로 작업을 큐에 추가
+                    workManager.enqueueUniquePeriodicWork(
+                        "HospitalReservationCheck",
+                        ExistingPeriodicWorkPolicy.UPDATE,
+                        reservationWorkRequest
+                    )
 
-            binding.statusTextView.text = "확인 작업이 시작되었습니다. 15분마다 백그라운드에서 실행됩니다."
-            Toast.makeText(this, "예약 확인을 시작합니다.", Toast.LENGTH_SHORT).show()
+                    binding.statusTextView.text = "확인 작업이 시작되었습니다. 15분마다 백그라운드에서 실행됩니다."
+                    Toast.makeText(this@MainActivity, "예약 확인을 시작합니다.", Toast.LENGTH_SHORT).show()
+                } else {
+                    Toast.makeText(
+                        this@MainActivity,
+                        "로그인 실패: ${loginResult.exceptionOrNull()?.message}",
+                        Toast.LENGTH_SHORT
+                    ).show()
+                }
+            }
         }
 
         // "중지" 버튼을 눌렀을 때

--- a/app/src/main/java/com/example/hospitalnotifier/network/ApiClient.kt
+++ b/app/src/main/java/com/example/hospitalnotifier/network/ApiClient.kt
@@ -1,5 +1,7 @@
 package com.example.hospitalnotifier.network
 
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 
@@ -8,8 +10,18 @@ object ApiClient {
     private const val BASE_URL = "https://www.snuh.org"
 
     val instance: ApiService by lazy {
+        val logging = HttpLoggingInterceptor().apply {
+            level = HttpLoggingInterceptor.Level.BASIC
+        }
+
+        val client = OkHttpClient.Builder()
+            .addInterceptor(logging)
+            .followRedirects(false) // 리다이렉트 수동 처리
+            .build()
+
         val retrofit = Retrofit.Builder()
             .baseUrl(BASE_URL)
+            .client(client)
             .addConverterFactory(GsonConverterFactory.create())
             .build()
         retrofit.create(ApiService::class.java)

--- a/app/src/main/java/com/example/hospitalnotifier/network/ApiService.kt
+++ b/app/src/main/java/com/example/hospitalnotifier/network/ApiService.kt
@@ -1,5 +1,6 @@
 package com.example.hospitalnotifier.network
 
+import okhttp3.ResponseBody
 import retrofit2.Response
 import retrofit2.http.Field
 import retrofit2.http.FormUrlEncoded
@@ -14,12 +15,18 @@ data class ScheduleItem(val meddate: String?)
 
 // 어떤 주소로 통신할지 정의하는 메뉴판
 interface ApiService {
-    // 로그인 요청 (실제 요청 경로는 병원 웹사이트에 맞게 수정 필요)
+    // 로그인 페이지 로딩 (CSRF 토큰 및 초기 쿠키 추출용)
+    @GET("/login.do")
+    suspend fun fetchLoginPage(): Response<ResponseBody>
+
+    // 로그인 요청 (필수 파라미터와 헤더를 함께 전달)
     @FormUrlEncoded
     @POST("/login.do")
     suspend fun login(
+        @Header("Cookie") cookie: String,
         @Field("id") userId: String,
-        @Field("pass") userPw: String
+        @Field("pass") userPw: String,
+        @Field("csrfToken") csrfToken: String
     ): Response<Void>
 
     // 예약 가능일 확인 요청
@@ -31,3 +38,4 @@ interface ApiService {
         @Query("nextDt") nextDt: String
     ): ScheduleResponse
 }
+

--- a/app/src/main/java/com/example/hospitalnotifier/network/AuthRepository.kt
+++ b/app/src/main/java/com/example/hospitalnotifier/network/AuthRepository.kt
@@ -1,0 +1,61 @@
+package com.example.hospitalnotifier.network
+
+import android.util.Log
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/**
+ * 로그인 절차를 담당하는 리포지토리.
+ * 1) 로그인 페이지를 불러 CSRF 토큰과 초기 쿠키를 얻는다.
+ * 2) 해당 토큰과 함께 로그인 요청을 보내고 세션 쿠키를 반환한다.
+ */
+object AuthRepository {
+    private const val TAG = "AuthRepository"
+
+    /**
+     * 로그인 시도 후 세션 쿠키를 반환한다. 실패 시 예외를 발생시킨다.
+     */
+    suspend fun login(userId: String, userPw: String): Result<String> =
+        withContext(Dispatchers.IO) {
+            try {
+                // 1. 로그인 페이지 조회
+                val pageResponse = ApiClient.instance.fetchLoginPage()
+                val initialCookie = pageResponse.headers().values("Set-Cookie").joinToString("; ")
+                val html = pageResponse.body()?.string().orEmpty()
+
+                // CSRF 토큰 파싱 (일반적으로 name="csrfToken" 또는 name="_csrf")
+                val csrfToken = Regex("name=\"csrfToken\" value=\"([^\"]+)\"")
+                    .find(html)?.groupValues?.get(1)
+                    ?: Regex("name=\"_csrf\" value=\"([^\"]+)\"")
+                        .find(html)?.groupValues?.get(1)
+
+                if (csrfToken.isNullOrEmpty()) {
+                    Log.e(TAG, "CSRF 토큰 파싱 실패")
+                    return@withContext Result.failure(Exception("Token parsing failed"))
+                }
+
+                // 2. 로그인 요청
+                val loginResponse = ApiClient.instance.login(initialCookie, userId, userPw, csrfToken)
+                if (loginResponse.code() in 300..399) {
+                    Log.e(TAG, "Unexpected redirect: ${loginResponse.headers()["Location"]}")
+                }
+
+                if (!loginResponse.isSuccessful) {
+                    Log.e(TAG, "로그인 실패: ${loginResponse.code()}")
+                    return@withContext Result.failure(Exception("Login failed"))
+                }
+
+                val sessionCookie = loginResponse.headers().values("Set-Cookie").joinToString("; ")
+                if (sessionCookie.isEmpty()) {
+                    Log.e(TAG, "세션 쿠키 추출 실패")
+                    return@withContext Result.failure(Exception("No session cookie"))
+                }
+
+                Result.success(sessionCookie)
+            } catch (e: Exception) {
+                Log.e(TAG, "로그인 오류: ${e.message}")
+                Result.failure(e)
+            }
+        }
+}
+


### PR DESCRIPTION
## Summary
- Add Retrofit calls to fetch login form and submit credentials with CSRF token
- Introduce `AuthRepository` handling login handshake and cookie extraction
- Verify credentials from UI before scheduling background worker
- Configure OkHttp client with basic logging and manual redirect handling

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6897046035648330b030eab2db66b8ac