### PR TITLE
Use loginProc endpoint and send form headers

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -67,6 +67,8 @@ dependencies {
     implementation(libs.androidx.activity)
     implementation(libs.androidx.constraintlayout)
     testImplementation(libs.junit)
+    testImplementation("androidx.test:core:1.5.0")
+    testImplementation("org.robolectric:robolectric:4.10.3")
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
 }

--- a/app/src/main/java/com/example/hospitalnotifier/network/ApiClient.kt
+++ b/app/src/main/java/com/example/hospitalnotifier/network/ApiClient.kt
@@ -50,7 +50,16 @@ object ApiClient {
     }
 
     fun getLoginApi(context: Context): SnuhLoginApi {
-        val okHttpClient = baseClient(context).build()
+        val okHttpClient = baseClient(context)
+            .addInterceptor { chain ->
+                val original = chain.request()
+                val request = original.newBuilder()
+                    .header("Referer", "https://www.snuh.org/login.do")
+                    .header("X-Requested-With", "XMLHttpRequest")
+                    .build()
+                chain.proceed(request)
+            }
+            .build()
 
         val retrofit = Retrofit.Builder()
             .baseUrl(BASE_URL)

--- a/app/src/main/java/com/example/hospitalnotifier/network/SnuhLoginApi.kt
+++ b/app/src/main/java/com/example/hospitalnotifier/network/SnuhLoginApi.kt
@@ -6,7 +6,7 @@ import retrofit2.http.POST
 
 interface SnuhLoginApi {
     @FormUrlEncoded
-    @POST("loginAjax.do")
+    @POST("loginProc.do")
     suspend fun login(
         @Field("id") id: String,
         @Field("pass") password: String

--- a/app/src/test/java/com/example/hospitalnotifier/MyCookieJarTest.kt
+++ b/app/src/test/java/com/example/hospitalnotifier/MyCookieJarTest.kt
@@ -1,0 +1,36 @@
+package com.example.hospitalnotifier
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class MyCookieJarTest {
+    @Test
+    fun `loginProc sets JSESSIONID1`() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val cookieJar = MyCookieJar(context)
+
+        val client = OkHttpClient.Builder()
+            .cookieJar(cookieJar)
+            .build()
+
+        val request = Request.Builder()
+            .url("https://www.snuh.org/loginProc.do")
+            .post(byteArrayOf().toRequestBody())
+            .build()
+
+        val response = client.newCall(request).execute()
+        assertEquals(200, response.code)
+
+        val prefs = context.getSharedPreferences("cookies", Context.MODE_PRIVATE)
+        assertNotNull(prefs.getString("JSESSIONID1", null))
+    }
+}


### PR DESCRIPTION
## Summary
- Point Snuh login API at `loginProc.do`
- Send form headers when creating the login API client
- Add test dependencies and verify cookie storage on login

## Testing
- `curl -D - -o /dev/null -X POST https://www.snuh.org/loginProc.do -d ''`
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68986e5c9c908330a53900a1da63f37e