### PR TITLE
Validate login before continuing reservation checks

### DIFF
--- a/app/src/main/java/com/example/hospitalnotifier/MainActivity.kt
+++ b/app/src/main/java/com/example/hospitalnotifier/MainActivity.kt
@@ -64,9 +64,22 @@ class MainActivity : AppCompatActivity() {
                 runOnUiThread {
                     isLoginProcessing = false
                     appendLog("로그인 시도 결과: $response")
-                    saveLoginData(id, password)
-                    startPeriodicCheck()
-                    Toast.makeText(this@MainActivity, "로그인 성공. 예약 조회를 시작합니다.", Toast.LENGTH_SHORT).show()
+                    if (response.contains("SUCCESS")) {
+                        saveLoginData(id, password)
+                        startPeriodicCheck()
+                        Toast.makeText(
+                            this@MainActivity,
+                            "로그인 성공. 예약 조회를 시작합니다.",
+                            Toast.LENGTH_SHORT
+                        ).show()
+                    } else {
+                        appendLog("로그인 실패: $response")
+                        Toast.makeText(
+                            this@MainActivity,
+                            "로그인 실패: $response",
+                            Toast.LENGTH_LONG
+                        ).show()
+                    }
                 }
             } catch (e: Exception) {
                 runOnUiThread {

--- a/app/src/main/java/com/example/hospitalnotifier/ReservationWorker.kt
+++ b/app/src/main/java/com/example/hospitalnotifier/ReservationWorker.kt
@@ -89,8 +89,13 @@ class ReservationWorker(private val appContext: Context, workerParams: WorkerPar
 
     private suspend fun startLoginProcess(id: String, password: String): Boolean {
         return try {
-            ApiClient.getLoginApi(appContext).login(id, password)
-            true
+            val response = ApiClient.getLoginApi(appContext).login(id, password)
+            if (response.contains("SUCCESS")) {
+                true
+            } else {
+                Log.e(TAG, "로그인 실패 응답: $response")
+                false
+            }
         } catch (e: Exception) {
             Log.e(TAG, "로그인 실패: ${'$'}{e.message}")
             false

--- a/app/src/main/java/com/example/hospitalnotifier/network/ApiClient.kt
+++ b/app/src/main/java/com/example/hospitalnotifier/network/ApiClient.kt
@@ -54,7 +54,11 @@ object ApiClient {
             .addInterceptor { chain ->
                 val original = chain.request()
                 val request = original.newBuilder()
-                    .header("Referer", "https://www.snuh.org/login.do")
+                    .header("Referer", "https://www.snuh.org/login/login.do")
+                    .header(
+                        "User-Agent",
+                        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36"
+                    )
                     .header("X-Requested-With", "XMLHttpRequest")
                     .build()
                 chain.proceed(request)


### PR DESCRIPTION
## Summary
- Ensure login API uses same headers as reservation client, including Referer, User-Agent, and X-Requested-With
- Verify login responses contain `SUCCESS` before starting background or periodic tasks
- Retry work if login response is unsuccessful

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68987858f600833094033146447d319d