### PR TITLE
Add headers to login API

### DIFF
--- a/app/src/main/java/com/example/hospitalnotifier/network/ApiClient.kt
+++ b/app/src/main/java/com/example/hospitalnotifier/network/ApiClient.kt
@@ -11,6 +11,8 @@ import retrofit2.converter.scalars.ScalarsConverterFactory
 
 object ApiClient {
     private const val BASE_URL = "https://www.snuh.org/"
+    private const val USER_AGENT =
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36"
 
     private fun baseClient(context: Context): OkHttpClient.Builder {
         val loggingInterceptor = HttpLoggingInterceptor().apply {
@@ -29,10 +31,7 @@ object ApiClient {
                 val original = chain.request()
                 val requestBuilder = original.newBuilder()
                     .header("Referer", "https://www.snuh.org/reservation/reservation.do")
-                    .header(
-                        "User-Agent",
-                        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36"
-                    )
+                    .header("User-Agent", USER_AGENT)
                     .header("X-Requested-With", "XMLHttpRequest")
                 val request = requestBuilder.build()
                 chain.proceed(request)
@@ -53,14 +52,11 @@ object ApiClient {
         val okHttpClient = baseClient(context)
             .addInterceptor { chain ->
                 val original = chain.request()
-                val request = original.newBuilder()
+                val requestBuilder = original.newBuilder()
                     .header("Referer", "https://www.snuh.org/login/login.do")
-                    .header(
-                        "User-Agent",
-                        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36"
-                    )
+                    .header("User-Agent", USER_AGENT)
                     .header("X-Requested-With", "XMLHttpRequest")
-                    .build()
+                val request = requestBuilder.build()
                 chain.proceed(request)
             }
             .build()


### PR DESCRIPTION
## Summary
- Extract USER_AGENT constant for shared headers
- Send Referer, User-Agent and X-Requested-With headers in login API requests

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689885ac072083308a3088946bd13166