### PR TITLE
Initialize login session before Snuh login

### DIFF
--- a/app/src/main/java/com/example/hospitalnotifier/MainActivity.kt
+++ b/app/src/main/java/com/example/hospitalnotifier/MainActivity.kt
@@ -61,8 +61,10 @@ class MainActivity : AppCompatActivity() {
 
         CoroutineScope(Dispatchers.IO).launch {
             try {
-                val response = ApiClient.getLoginApi(this@MainActivity).login(id, password)
-                if (!response.contains("SUCCESS")) {
+                val loginApi = ApiClient.getLoginApi(this@MainActivity)
+                loginApi.initSession()
+                val response = loginApi.login(id, password)
+                if (response.contains("login.do")) {
                     Log.e(TAG, "로그인 실패 응답: $response")
                     runOnUiThread {
                         isLoginProcessing = false
@@ -87,11 +89,11 @@ class MainActivity : AppCompatActivity() {
                     ).show()
                 }
             } catch (e: Exception) {
-                Log.e(TAG, "로그인 실패: ${e.message}")
+                Log.e(TAG, "로그인 실패: ${'$'}{e.message}")
                 runOnUiThread {
                     isLoginProcessing = false
-                    appendLog("로그인 실패: ${e.message}")
-                    Toast.makeText(this@MainActivity, "로그인 실패: ${e.message}", Toast.LENGTH_LONG).show()
+                    appendLog("로그인 실패: ${'$'}{e.message}")
+                    Toast.makeText(this@MainActivity, "로그인 실패: ${'$'}{e.message}", Toast.LENGTH_LONG).show()
                 }
             }
         }

--- a/app/src/main/java/com/example/hospitalnotifier/ReservationWorker.kt
+++ b/app/src/main/java/com/example/hospitalnotifier/ReservationWorker.kt
@@ -92,15 +92,17 @@ class ReservationWorker(private val appContext: Context, workerParams: WorkerPar
 
     private suspend fun startLoginProcess(id: String, password: String): Result {
         return try {
-            val response = ApiClient.getLoginApi(appContext).login(id, password)
-            if (response.contains("SUCCESS")) {
-                Result.success()
-            } else {
+            val loginApi = ApiClient.getLoginApi(appContext)
+            loginApi.initSession()
+            val response = loginApi.login(id, password)
+            if (response.contains("login.do")) {
                 Log.e(TAG, "로그인 실패 응답: $response")
                 Result.failure()
+            } else {
+                Result.success()
             }
         } catch (e: Exception) {
-            Log.e(TAG, "로그인 실패: ${e.message}")
+            Log.e(TAG, "로그인 실패: ${'$'}{e.message}")
             Result.retry()
         }
     }

--- a/app/src/main/java/com/example/hospitalnotifier/network/ApiClient.kt
+++ b/app/src/main/java/com/example/hospitalnotifier/network/ApiClient.kt
@@ -54,7 +54,7 @@ object ApiClient {
             .addInterceptor { chain ->
                 val original = chain.request()
                 val requestBuilder = original.newBuilder()
-                    .header("Referer", "https://www.snuh.org/login/login.do")
+                    .header("Referer", "https://www.snuh.org/login.do")
                     .header("User-Agent", USER_AGENT)
                     .header("X-Requested-With", "XMLHttpRequest")
                 val request = requestBuilder.build()

--- a/app/src/main/java/com/example/hospitalnotifier/network/SnuhLoginApi.kt
+++ b/app/src/main/java/com/example/hospitalnotifier/network/SnuhLoginApi.kt
@@ -2,13 +2,18 @@ package com.example.hospitalnotifier.network
 
 import retrofit2.http.Field
 import retrofit2.http.FormUrlEncoded
+import retrofit2.http.GET
 import retrofit2.http.POST
 
 interface SnuhLoginApi {
+    @GET("login.do")
+    suspend fun initSession(): String
+
     @FormUrlEncoded
     @POST("loginProc.do")
     suspend fun login(
         @Field("id") id: String,
-        @Field("pass") password: String
+        @Field("pass") password: String,
+        @Field("retUrl") retUrl: String = ""
     ): String
 }


### PR DESCRIPTION
## Summary
- Initialize session cookies before logging in
- Add optional retUrl field to Snuh login request
- Fail fast when login response returns login page

## Testing
- `bash ./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68988e9429288330ab8d9ce5983ac5a2