### PR TITLE
Consolidate network models and APIs

### DIFF
--- a/app/src/main/java/com/example/hospitalnotifier/ScheduleResponse.kt
+++ b/app/src/main/java/com/example/hospitalnotifier/ScheduleResponse.kt
@@ -1,9 +1,0 @@
-package com.example.hospitalnotifier
-
-data class ScheduleResponse(
-    val scheduleList: List<Schedule>?
-)
-
-data class Schedule(
-    val meddate: String?
-)

--- a/app/src/main/java/com/example/hospitalnotifier/network/ScheduleResponse.kt
+++ b/app/src/main/java/com/example/hospitalnotifier/network/ScheduleResponse.kt
@@ -1,0 +1,16 @@
+package com.example.hospitalnotifier.network
+
+/**
+ * Represents the response from the SNUH schedule API.
+ */
+data class ScheduleResponse(
+    val scheduleList: List<ScheduleItem>?
+)
+
+/**
+ * Represents a schedule item containing the medical date.
+ */
+data class ScheduleItem(
+    val meddate: String?
+)
+

--- a/app/src/main/java/com/example/hospitalnotifier/network/SnuhApi.kt
+++ b/app/src/main/java/com/example/hospitalnotifier/network/SnuhApi.kt
@@ -4,9 +4,6 @@ import retrofit2.Response
 import retrofit2.http.GET
 import retrofit2.http.Query
 
-data class ScheduleResponse(val scheduleList: List<ScheduleItem>?)
-data class ScheduleItem(val meddate: String?)
-
 interface SnuhApi {
     @GET("reservation/medDateListAjax.do")
     suspend fun checkAvailability(

--- a/app/src/main/java/com/example/hospitalnotifier/network/TelegramApi.kt
+++ b/app/src/main/java/com/example/hospitalnotifier/network/TelegramApi.kt
@@ -1,4 +1,4 @@
-package com.example.hospitalnotifier
+package com.example.hospitalnotifier.network
 
 import retrofit2.Response
 import retrofit2.http.Field
@@ -17,3 +17,4 @@ interface TelegramApi {
         @Field("parse_mode") parseMode: String = "Markdown"
     ): Response<String>
 }
+

--- a/app/src/main/java/com/example/hospitalnotifier/network/TelegramClient.kt
+++ b/app/src/main/java/com/example/hospitalnotifier/network/TelegramClient.kt
@@ -4,21 +4,6 @@ import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.converter.scalars.ScalarsConverterFactory
-import retrofit2.http.Field
-import retrofit2.http.FormUrlEncoded
-import retrofit2.http.POST
-import retrofit2.http.Path
-
-interface TelegramApi {
-    @FormUrlEncoded
-    @POST("/bot{token}/sendMessage")
-    suspend fun sendMessage(
-        @Path("token") token: String,
-        @Field("chat_id") chatId: String,
-        @Field("text") text: String,
-        @Field("parse_mode") parseMode: String = "Markdown"
-    ): retrofit2.Response<String>
-}
 
 object TelegramClient {
 


### PR DESCRIPTION
## Summary
- Move ScheduleResponse/ScheduleItem data classes into network package
- Relocate TelegramApi into network package and use it from TelegramClient
- Update SnuhApi to use shared models

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898ab4efbdc83308bd038395cb8cc92