### PR TITLE
Add network timeouts to API client

### DIFF
--- a/Patch Notes.md
+++ b/Patch Notes.md
@@ -15,3 +15,7 @@ Patch Notes(지시사항-작업내용 순)
 - 지시사항: 예약 조회 실패 시 오류 로그 및 진행상태 메시지를 전송하여 UI에서 진단 정보를 표시하도록 할 것.
 - 작업방향 수정내용: 해당 없음.
 - 작업내용: ReservationWorker.kt의 예약 조회 예외 처리에 Log.e와 setProgress를 추가하여 오류 메시지를 기록하고 전송하도록 수정.
+
+- 지시사항: baseClient에 네트워크 타임아웃을 설정하고 TimeUnit을 임포트할 것.
+- 작업방향 수정내용: 해당 없음.
+- 작업내용: ApiClient.kt의 baseClient에 connectTimeout 10초, readTimeout 10초, callTimeout 20초를 추가하고 java.util.concurrent.TimeUnit을 임포트함.

--- a/app/src/main/java/com/example/hospitalnotifier/network/ApiClient.kt
+++ b/app/src/main/java/com/example/hospitalnotifier/network/ApiClient.kt
@@ -3,6 +3,7 @@ package com.example.hospitalnotifier.network
 import android.content.Context
 import com.example.hospitalnotifier.MyCookieJar
 import com.google.gson.GsonBuilder
+import java.util.concurrent.TimeUnit
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
@@ -22,6 +23,9 @@ object ApiClient {
         return OkHttpClient.Builder()
             .cookieJar(MyCookieJar(context))
             .addInterceptor(loggingInterceptor)
+            .connectTimeout(10, TimeUnit.SECONDS)
+            .readTimeout(10, TimeUnit.SECONDS)
+            .callTimeout(20, TimeUnit.SECONDS)
     }
 
     private fun gson() = GsonBuilder().setLenient().create()


### PR DESCRIPTION
## Summary
- Configure base OkHttp client with connect, read, and call timeouts
- Import TimeUnit for timeout configuration
- Document change in Patch Notes

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898bebb8a948330a9ef62c224db7a40