### PR TITLE
Verify session cookie after login

### DIFF
--- a/Patch Notes.md
+++ b/Patch Notes.md
@@ -23,3 +23,7 @@ Patch Notes(지시사항-작업내용 순)
 - 지시사항: checkAvailability 응답에서 401/302 외의 비성공 HTTP 코드를 처리하고, 상태코드·에러본문을 로그와 진행상태로 전송하며, 서버 오류는 재시도, 기타는 실패로 처리할 것.
 - 작업방향 수정내용: 해당 없음.
 - 작업내용: ReservationWorker.kt에 비성공 응답 처리 분기를 추가해 HTTP 상태코드와 errorBody를 기록하고 진행상태로 전송하며, 5xx는 Result.retry(), 그 외는 Result.failure()를 반환하도록 수정.
+
+- 지시사항: 로그인 후 세션 쿠키(JSESSIONID1) 확보 여부를 확인하고, 없으면 오류 로그·진행상태 갱신 후 실패를 반환하며, 성공 시 쿠키 이름/값을 로그로 남길 것.
+- 작업방향 수정내용: 해당 없음.
+- 작업내용: ReservationWorker.startLoginProcess에서 로그인 후 SharedPreferences의 JSESSIONID1 쿠키를 검사하는 로직을 추가하고, 미존재 시 setProgress와 함께 Result.failure()를 반환하도록 수정. 쿠키 존재 시 이름/값을 로그로 출력하며, MyCookieJarTest에 성공/실패 시나리오를 검증하는 테스트와 MockK 및 WorkManager 테스트 의존성을 추가.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -70,6 +70,8 @@ dependencies {
     testImplementation("androidx.test:core:1.5.0")
     testImplementation("org.robolectric:robolectric:4.10.3")
     testImplementation("com.squareup.okhttp3:mockwebserver:4.11.0")
+    testImplementation("io.mockk:mockk:1.13.7")
+    testImplementation("androidx.work:work-testing:2.9.0")
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
 }


### PR DESCRIPTION
## Summary
- Ensure login acquires JSESSIONID1 session cookie and fail otherwise
- Log acquired cookie for debugging
- Test login cookie validation with MockK and WorkManager test harness

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898ca786f108330ad87533aa21741dd