### PR TITLE
Use periodic work only and cancel all running work

### DIFF
--- a/Patch Notes.md
+++ b/Patch Notes.md
@@ -39,3 +39,7 @@ Patch Notes(지시사항-작업내용 순)
 - 지시사항: ReservationWorker.startLoginProcess 실행 직전에 cookies SharedPreferences를 clear()하여 기존 세션을 제거하고, 로그인 후 필수 세션 쿠키를 확인하여 없으면 "세션 쿠키 없음" 상태 로그와 함께 실패를 반환하며, 실패 시 cookies와 로그인 정보 저장소에서 관련 항목을 삭제할 것.
 - 작업방향 수정내용: 해당 없음.
 - 작업내용: ReservationWorker.kt에서 startLoginProcess 호출 전 clearCookies()를 수행하고, 로그인 후 JSESSIONID1 검증 실패 시 상태 로그를 남기고 cookies 및 settings에서 쿠키와 로그인 정보를 제거하도록 수정. 실패 테스트에 이러한 정리 동작을 확인하는 단위 테스트 보강.
+
+- 지시사항: MainActivity.startWork에서 즉시 실행이 필요하지 않으면 원타임 WorkRequest를 제거하고 주기 작업만 사용하며, stopWork에서 현재 실행 중인 작업을 cancelAllWorkByTag(WORK_TAG)로 중단할 것.
+- 작업방향 수정내용: 해당 없음.
+- 작업내용: MainActivity.kt의 startWork를 enqueueUniquePeriodicWork만 사용하도록 정리하고, stopWork에서 cancelAllWorkByTag를 호출하여 실행 중인 작업을 즉시 취소하도록 변경.

--- a/app/src/main/java/com/example/hospitalnotifier/MainActivity.kt
+++ b/app/src/main/java/com/example/hospitalnotifier/MainActivity.kt
@@ -160,19 +160,6 @@ class MainActivity : AppCompatActivity() {
     private fun startWork() {
         val intervalMinutes = binding.spinnerInterval.selectedItem as Float
         val workManager = WorkManager.getInstance(this)
-
-        workManager.cancelAllWorkByTag(WORK_TAG)
-
-        val oneTimeRequest = OneTimeWorkRequestBuilder<ReservationWorker>()
-            .addTag(WORK_TAG)
-            .build()
-
-        workManager.enqueueUniqueWork(
-            WORK_TAG,
-            ExistingWorkPolicy.REPLACE,
-            oneTimeRequest
-        )
-
         val periodicRequest = PeriodicWorkRequestBuilder<ReservationWorker>(
             intervalMinutes.toLong(), TimeUnit.MINUTES
         )
@@ -189,7 +176,7 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun stopWork() {
-        WorkManager.getInstance(this).cancelUniqueWork(WORK_TAG)
+        WorkManager.getInstance(this).cancelAllWorkByTag(WORK_TAG)
         currentWorkId = null
         observedIds.clear()
         Toast.makeText(this, "예약 조회를 중지합니다.", Toast.LENGTH_SHORT).show()


### PR DESCRIPTION
## Summary
- remove one-time worker in MainActivity.startWork and rely solely on a unique periodic work request
- stopWork now cancels any running work instances by tag
- document the change in Patch Notes

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898e78be90c83308dab27c294a03caa