### PR TITLE
Generalize session cookie retrieval in startLoginProcess

### DIFF
--- a/Patch Notes.md
+++ b/Patch Notes.md
@@ -43,3 +43,7 @@ Patch Notes(지시사항-작업내용 순)
 - 지시사항: MainActivity.startWork에서 즉시 실행이 필요하지 않으면 원타임 WorkRequest를 제거하고 주기 작업만 사용하며, stopWork에서 현재 실행 중인 작업을 cancelAllWorkByTag(WORK_TAG)로 중단할 것.
 - 작업방향 수정내용: 해당 없음.
 - 작업내용: MainActivity.kt의 startWork를 enqueueUniquePeriodicWork만 사용하도록 정리하고, stopWork에서 cancelAllWorkByTag를 호출하여 실행 중인 작업을 즉시 취소하도록 변경.
+
+- 지시사항: startLoginProcess에서 세션 쿠키 검색을 JSESSIONID 접두사 전체로 일반화하고, 쿠키를 찾지 못한 경우에만 실패로 처리할 것.
+- 작업방향 수정내용: 해당 없음.
+- 작업내용: ReservationWorker.kt에서 JSESSIONID1 대신 JSESSIONID 접두사를 검색하도록 수정하고, MyCookieJarTest.kt의 성공 시나리오에서 JSESSIONID2 쿠키로 검증하도록 변경.

--- a/app/src/main/java/com/example/hospitalnotifier/ReservationWorker.kt
+++ b/app/src/main/java/com/example/hospitalnotifier/ReservationWorker.kt
@@ -127,9 +127,9 @@ class ReservationWorker(private val appContext: Context, workerParams: WorkerPar
                 Result.failure()
             } else {
                 val cookiesPref = appContext.getSharedPreferences("cookies", Context.MODE_PRIVATE)
-                val session = cookiesPref.all.entries.firstOrNull { it.key.contains("JSESSIONID1") }
+                val session = cookiesPref.all.entries.firstOrNull { it.key.contains("JSESSIONID") }
                 if (session == null) {
-                    Log.e(TAG, "세션 쿠키(JSESSIONID1) 미확보")
+                    Log.e(TAG, "세션 쿠키(JSESSIONID) 미확보")
                     setProgress(workDataOf("status" to "세션 쿠키 없음"))
                     clearCookies()
                     clearLoginInfo()

--- a/app/src/test/java/com/example/hospitalnotifier/MyCookieJarTest.kt
+++ b/app/src/test/java/com/example/hospitalnotifier/MyCookieJarTest.kt
@@ -91,7 +91,7 @@ class MyCookieJarTest {
         val loginApi = mockk<SnuhLoginApi>()
         coEvery { loginApi.initSession() } returns ""
         coEvery { loginApi.login(any(), any(), any()) } answers {
-            cookiePrefs.edit().putString("www.snuh.org|/|JSESSIONID1", "JSESSIONID1=test; Path=/").apply()
+            cookiePrefs.edit().putString("www.snuh.org|/|JSESSIONID2", "JSESSIONID2=test; Path=/").apply()
             ""
         }
 
@@ -101,7 +101,7 @@ class MyCookieJarTest {
         val worker = TestListenableWorkerBuilder<ReservationWorker>(context).build()
         val result = worker.startLoginProcess("id", "pass")
         assertTrue(result is Result.Success)
-        assertNotNull(cookiePrefs.all.keys.firstOrNull { it.contains("JSESSIONID1") })
+        assertNotNull(cookiePrefs.all.keys.firstOrNull { it.contains("JSESSIONID2") })
 
         unmockkAll()
     }


### PR DESCRIPTION
## Summary
- broaden JSESSIONID cookie lookup to accept any prefix
- adjust unit test to validate with JSESSIONID2
- document change in Patch Notes

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899771e12288330acec012dc48727d6