### PR TITLE
Handle missing credentials and login errors

### DIFF
--- a/Patch Notes.md
+++ b/Patch Notes.md
@@ -51,3 +51,7 @@ Patch Notes(지시사항-작업내용 순)
 - 지시사항: startLoginProcess에서 clearLoginInfo() 호출을 제거하거나 조건부로 실행하고, 실패해도 settings에 저장된 ID/비밀번호가 유지되도록 할 것.
 - 작업방향 수정내용: 해당 없음.
 - 작업내용: ReservationWorker.kt에서 세션 쿠키 미확보나 로그인 예외 시 clearLoginInfo() 호출을 제거해 로그인 정보를 유지하고, 사용자 입력이 잘못된 경우에만 clearLoginInfo()가 실행되도록 수정함.
+
+- 지시사항: doWork에서 ID, 비밀번호, 조회 월이 없을 때 각각 진행상태에 원인을 기록하고 실패를 반환하며, startLoginProcess에서 로그인 실패(response에 login.do 포함 또는 예외 발생) 시에도 "로그인 실패:" 메시지를 진행상태에 기록할 것.
+- 작업방향 수정내용: 해당 없음.
+- 작업내용: ReservationWorker.kt에서 각 null 항목에 대한 setProgress와 실패 처리를 추가하고, 로그인 실패 상황에서도 setProgress로 원인을 전달하도록 수정함.

--- a/app/src/main/java/com/example/hospitalnotifier/ReservationWorker.kt
+++ b/app/src/main/java/com/example/hospitalnotifier/ReservationWorker.kt
@@ -20,9 +20,18 @@ class ReservationWorker(private val appContext: Context, workerParams: WorkerPar
         setProgress(workDataOf("status" to "Worker started"))
 
         val sharedPref = appContext.getSharedPreferences("settings", Context.MODE_PRIVATE)
-        val id = sharedPref.getString("id", null) ?: return Result.failure()
-        val password = sharedPref.getString("password", null) ?: return Result.failure()
-        val targetMonths = sharedPref.getString("targetMonths", null) ?: return Result.failure()
+        val id = sharedPref.getString("id", null) ?: run {
+            setProgress(workDataOf("status" to "ID 없음"))
+            return Result.failure()
+        }
+        val password = sharedPref.getString("password", null) ?: run {
+            setProgress(workDataOf("status" to "비밀번호 없음"))
+            return Result.failure()
+        }
+        val targetMonths = sharedPref.getString("targetMonths", null) ?: run {
+            setProgress(workDataOf("status" to "조회 월 없음"))
+            return Result.failure()
+        }
         val token = sharedPref.getString("telegramToken", null)
         val chatId = sharedPref.getString("telegramChatId", null)
 
@@ -122,6 +131,7 @@ class ReservationWorker(private val appContext: Context, workerParams: WorkerPar
             val response = loginApi.login(id, password)
             if (response.contains("login.do")) {
                 Log.e(TAG, "로그인 실패 응답: $response")
+                setProgress(workDataOf("status" to "로그인 실패: login.do 응답"))
                 clearCookies()
                 clearLoginInfo()
                 Result.failure()
@@ -140,6 +150,7 @@ class ReservationWorker(private val appContext: Context, workerParams: WorkerPar
             }
         } catch (e: Exception) {
             Log.e(TAG, "로그인 실패: ${'$'}{e.message}")
+            setProgress(workDataOf("status" to "로그인 실패: ${'$'}{e.message}"))
             clearCookies()
             Result.retry()
         }


### PR DESCRIPTION
## Summary
- Show progress messages when ID, password, or target months are absent
- Record login failure details in worker progress messages
- Update patch notes for new failure handling

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68997aba82f883308a255ceb5481a364