### PR TITLE
Preserve credentials on login failure

### DIFF
--- a/Patch Notes.md
+++ b/Patch Notes.md
@@ -63,3 +63,7 @@ Patch Notes(지시사항-작업내용 순)
 - 지시사항: 워커가 즉시 종료되는 경우에도 마지막 상태 메시지를 UI에서 확인할 수 있도록, 모든 조기 실패에서 상태를 outputData로 반환하고 성공 시에도 최종 메시지를 outputData에 포함할 것.
 - 작업방향 수정내용: 해당 없음.
 - 작업내용: ReservationWorker.kt에서 ID·비밀번호·조회 월 누락, 로그인 실패, 세션 쿠키 없음, 예약 조회 실패 등의 모든 Result.failure에 workDataOf("status" ...)를 제공하고, 조회 성공 시 마지막 메시지를 담은 Result.success(workDataOf("status" ...))를 반환하도록 변경.
+
+- 지시사항: startLoginProcess에서 clearLoginInfo() 호출을 제거하거나 조건부로 실행하고, 실패해도 settings에 저장된 ID/비밀번호가 유지되도록 할 것.
+- 작업방향 수정내용: 해당 없음.
+- 작업내용: ReservationWorker.kt에서 로그인 실패 시 clearLoginInfo() 호출을 삭제해 SharedPreferences에 ID/비밀번호가 남아 다음 예약 조회 주기에 재로그인을 시도할 수 있도록 수정함.

--- a/app/src/main/java/com/example/hospitalnotifier/ReservationWorker.kt
+++ b/app/src/main/java/com/example/hospitalnotifier/ReservationWorker.kt
@@ -137,7 +137,6 @@ class ReservationWorker(private val appContext: Context, workerParams: WorkerPar
                 val message = "로그인 실패: login.do 응답"
                 setProgress(workDataOf("status" to message))
                 clearCookies()
-                clearLoginInfo()
                 Result.failure(workDataOf("status" to message))
             } else {
                 val cookiesPref = appContext.getSharedPreferences("cookies", Context.MODE_PRIVATE)


### PR DESCRIPTION
## Summary
- Skip `clearLoginInfo()` when login fails so saved credentials remain for subsequent retries
- Document change in Patch Notes

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68998c9976c08330a7c42769daf5ea9f