### PR TITLE
Use cookieJar for JSESSIONID1 test

### DIFF
--- a/app/src/test/java/com/example/hospitalnotifier/MyCookieJarTest.kt
+++ b/app/src/test/java/com/example/hospitalnotifier/MyCookieJarTest.kt
@@ -25,8 +25,6 @@ class MyCookieJarTest {
     @Test
     fun `loginProc sets JSESSIONID1`() {
         val context = ApplicationProvider.getApplicationContext<Context>()
-        val prefs = context.getSharedPreferences("cookies", Context.MODE_PRIVATE)
-        prefs.edit().clear().apply()
 
         val server = MockWebServer()
         server.enqueue(
@@ -50,8 +48,8 @@ class MyCookieJarTest {
             val response = client.newCall(request).execute()
             assertEquals(200, response.code)
 
-            val key = "${server.hostName}|/|JSESSIONID1"
-            assertNotNull(prefs.getString(key, null))
+            val cookies = cookieJar.getCookies(server.url("/").toString())
+            assertTrue(cookies.any { it.name == "JSESSIONID1" })
         } finally {
             server.shutdown()
         }


### PR DESCRIPTION
## Summary
- Verify JSESSIONID1 cookie using `MyCookieJar.getCookies` instead of reading from `SharedPreferences`

## Testing
- `./gradlew :app:testDebugUnitTest --tests com.example.hospitalnotifier.MyCookieJarTest` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b201ac7848330aebd47447ad731a9